### PR TITLE
Updated to use version 2.5.0 of the FindaCourse Nuget package

### DIFF
--- a/DFC.App.FindACourse.Repositories/DFC.App.FindACourse.Repository.csproj
+++ b/DFC.App.FindACourse.Repositories/DFC.App.FindACourse.Repository.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DFC.FindACourseClient" Version="2.4.2" />
+    <PackageReference Include="DFC.FindACourseClient" Version="2.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.App.FindACourse.Services/DFC.App.FindACourse.Services.csproj
+++ b/DFC.App.FindACourse.Services/DFC.App.FindACourse.Services.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DFC.FindACourseClient" Version="2.4.2" />
+    <PackageReference Include="DFC.FindACourseClient" Version="2.5.0" />
     <PackageReference Include="Azure.Search.Documents" Version="11.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated to use version 2.5.0 of the FindaCourse Nuget package that now only send request parameters in the search API request if they are going to filter the results