### PR TITLE
fix trailing space in hyperlinks in 'Additional courses in your local…

### DIFF
--- a/DFC.App.FindACourse/Views/Course/_results.cshtml
+++ b/DFC.App.FindACourse/Views/Course/_results.cshtml
@@ -95,15 +95,11 @@
                         <h2 class="govuk-heading-m">Additional courses in your local area</h2>
                         <p class="govuk-body-s">
                             You might find more courses with a training provider in your local area. Please see the full
-                            <a href="https://www.gov.uk/government/publications/find-a-free-level-3-qualification/list-of-colleges-and-training-providers-able-to-offer-free-places-for-level-3-qualifications">
-                                list of free courses for jobs providers
-                            </a> offering Level 3 courses.
+                            <a href="https://www.gov.uk/government/publications/find-a-free-level-3-qualification/list-of-colleges-and-training-providers-able-to-offer-free-places-for-level-3-qualifications">list of free courses for jobs providers</a> offering Level 3 courses.
                         </p>
                         <p class="govuk-body-s">
                             If you cannot find what you’re looking for, you can
-                            <a href="/contact-us">
-                                speak to an adviser
-                            </a>.
+                            <a href="/contact-us">speak to an adviser</a>.
                         </p>
                     </div>
                 }


### PR DESCRIPTION
… area' section