### PR TITLE
Merge Release 26 to master now live

### DIFF
--- a/DFC.App.FindACourse/Views/Course/SideBarLeft.cshtml
+++ b/DFC.App.FindACourse/Views/Course/SideBarLeft.cshtml
@@ -90,6 +90,7 @@
                     </div>
                 </fieldset>
             </div>
+            <div id="fac-qualification-level"><a id="qualification-level" class="govuk-link" href="https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" aria-label="QualificationFilters">What qualifications levels mean</a></div>
         </div>
     }
 

--- a/DFC.App.FindACourse/Views/Course/_result_heading.cshtml
+++ b/DFC.App.FindACourse/Views/Course/_result_heading.cshtml
@@ -34,5 +34,13 @@
             }
         }
     </span>
-    <span class="course-provider">&nbsp;&nbsp;@Html.Raw(Model.ProviderName)</span>
+
+    @if (Model.AttendanceMode == "Online")
+    {
+        <span class="course-provider">@Html.Raw(Model.ProviderName)</span>
+    }
+    else
+    {
+        <span class="course-provider">&nbsp;&nbsp;@Html.Raw(Model.ProviderName)</span>
+    }
 </p>

--- a/DFC.App.FindACourse/Views/Course/_results.cshtml
+++ b/DFC.App.FindACourse/Views/Course/_results.cshtml
@@ -183,21 +183,19 @@
         }
         else
         {
-            <hr class="govuk-section-break govuk-section-break--visible">
             <div id="fac-result-list">
                 <div id="fac-result-list-Result">
                     <div id="no-results-block">
-                        <h3 class="govuk-body-s govuk-!-margin-bottom-1">
-                            <p class="govuk-body">We didn't find any results for <span id="search-term-no-results">'@Html.Raw(Model.CurrentSearchTerm)'</span> with the active filters you've applied. Try searching again.</p>
-                            <p class="govuk-body">You could:</p>
+                        <p class="govuk-body govuk-!-font-weight-bold">No results found</p>
+                        <div class="govuk-body-s govuk-!-margin-bottom-1">
+                            <div class="govuk-body">To improve your search results, you could:</div>
                             <ul class="govuk-list--bullet govuk-body">
+                                <li>remove a filter</li>
+                                <li>search for something less specific</li>
                                 <li>check your spelling</li>
                                 <li>change the start date</li>
-                                <li>check your town or postcode</li>
-                                <li>change your filters</li>
-                                <li>try different search terms</li>
                             </ul>
-                        </h3>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -429,6 +429,14 @@
               {
                 "name": "Configuration__CourseSearch__BrandingAssetsCdn",
                 "value": "[parameters('BrandingAssetsCdn')]"
+              },
+              {
+                "name": "DOTNET_ROLL_FORWARD",
+                "value": "Minor"
+              }, 
+              {
+                "name": "DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX",
+                "value": "1"
               }
             ]
           }

--- a/Resources/AzureDevops/azure-pipelines.yml
+++ b/Resources/AzureDevops/azure-pipelines.yml
@@ -76,13 +76,13 @@ jobs:
       TestSuffix: UnitTests
 
 #Build UI functional Tests
-#- job: Builduifunctionaltests
-#  displayName: Build UI functional tests
-#  steps:
+- job: Builduifunctionaltests
+  displayName: Build UI functional tests
+  steps:
 # Build all UI Functional Tests that ends with UI.FunctionalTests
-#  - template: AzureDevOpsTemplates\Build\StepTemplates\dfc-dotnetcore-build-sonar.yml@dfc-devops
-#    parameters:
-#      SolutionBaseName: $(SolutionBaseName).UI.FunctionalTests
-#      BuildPlatform: $(BuildPlatform)
-#      BuildConfiguration: $(BuildConfiguration)
-#      DotNetCoreVersion: 3.1.101
+  - template: AzureDevOpsTemplates\Build\StepTemplates\dfc-dotnetcore-build-sonar.yml@dfc-devops
+    parameters:
+      SolutionBaseName: $(SolutionBaseName).UI.FunctionalTests
+      BuildPlatform: $(BuildPlatform)
+      BuildConfiguration: $(BuildConfiguration)
+      DotNetCoreVersion: 3.1.101

--- a/Resources/AzureDevops/azure-pipelines.yml
+++ b/Resources/AzureDevops/azure-pipelines.yml
@@ -76,13 +76,13 @@ jobs:
       TestSuffix: UnitTests
 
 #Build UI functional Tests
-- job: Builduifunctionaltests
-  displayName: Build UI functional tests
-  steps:
+#- job: Builduifunctionaltests
+#  displayName: Build UI functional tests
+#  steps:
 # Build all UI Functional Tests that ends with UI.FunctionalTests
-  - template: AzureDevOpsTemplates\Build\StepTemplates\dfc-dotnetcore-build-sonar.yml@dfc-devops
-    parameters:
-      SolutionBaseName: $(SolutionBaseName).UI.FunctionalTests
-      BuildPlatform: $(BuildPlatform)
-      BuildConfiguration: $(BuildConfiguration)
-      DotNetCoreVersion: 3.1.101
+#  - template: AzureDevOpsTemplates\Build\StepTemplates\dfc-dotnetcore-build-sonar.yml@dfc-devops
+#    parameters:
+#      SolutionBaseName: $(SolutionBaseName).UI.FunctionalTests
+#      BuildPlatform: $(BuildPlatform)
+#      BuildConfiguration: $(BuildConfiguration)
+#      DotNetCoreVersion: 3.1.101


### PR DESCRIPTION
* Add missing ampersand

* changes for Bug

* fix failing staging tests

* Add pagination test

* correct feature name

* update search term to work in both sit and pp

* [FT2-1319] Added sitemap with two paths (#275)

* Updating dfc.content.pck.netcore to latest version

* Updated app settings to work locally

* Added partial pages to show different layout for the find a course page

* Revert the course controller changes

* updated locaton input type to search

* Rmoved dev environemnt's keys

* updated images path

* Created corses for job page

* Added pages for the job courses. Updated FAC page layout to as per prototype.

* Added help page

* Updated assets path

* updated button css

* Fixed home page layout.

* Apply pagination

* Fixed paging issue

* Updated for free courses

* Added BrandingAssetsCdn to the appsettings

* Added paging

* Removed text

* Updated search result page layout

* Fixed unit tests error

* Style search result page

* Updated search result top section

* Added sidebar to the BodyViewModel

* Added consition to show "Result for" text when test has been entered.

* Removed cost funding page link

* Update search result page

* Reoved search heading

* added changes as per ncslt-1508

* Fixed margin/styling issue

* Added BandingAssetsCdn to CourseSearchSettings for images.

* Update template.json

Edited a AppSetting variable Configuration__CourseSearch__BrandingAssetsCdn

* Added autocomplte off for keywords search

* Added spacing between course location and provider

* Removed Did you meaction as per requirements

* Updated pagination to home office design

* Updated no results message, facd-224

* Updated no search result message

* Updated css class for the Search text

* Content changes

* Updated improve your skills

* Image and content changes

* Applied content changes

* Updated button text to 'Search for courses'

* Added hero banner

* Updated no results content page

* Update no results

* Added no cache for search result

* Added seperate pages for each page

* Updated content and images for beta 1 changes.

* Added findacourse route

* working home page

* Fixed static pages

* Fixed search

* code refact for read accessability

* updated home page action

* Applied foxfor clear filters

* Updated unit tests

* updated unit test for course controller

* Renamed herobanner

* Removed not required static pages

* Added auto suggestion to Search

* Add did you mean section

* Updated for loction auto suggestion

* Implemented did you mean functionality

* Updated for 'Did you mean' functionality

* Updated course search result and moved did you mean above the sho/hide filters

* Updated unit tests

* fixes for non javascript apply filter bugs and fix for did you mean functionality

* Updated did you mean content and fixed bug facd-468

* Used the fac class as govuk-list was conflicting with contact-us page

* fixed clear filter bug

* fixed clear filter bug (#306)




* Revert "fixed clear filter bug"

This reverts commit b833d602f6d7fe7cc07e5b86a0364de25b4305b6.

* Fixed mobile devices search issue

* Fixed pre-prod bugs facd-473 & 475

* Moved Clear Filters at top of the page

* Added qualifications level link

* Updated no results contents

* Move qualification level contents within group

* Remove props file to ensure we use the intended dotnet core version

* Issue with Automapper in Azure app servie using lastest .NET runtime

* Revert "Issue with Automapper in Azure app servie using lastest .NET runtime"

This reverts commit d7748638782e05de8610a1efc3b8e07a55526d9c.

* Revert "Remove props file to ensure we use the intended dotnet core version"

This reverts commit 09ec622aaf711aa1b4dee1065755c668effc604d.

* Setting runtime to lastminor

* fixed read accessibility issue

* Added Additional courses for free course search

* fix trailing space in hyperlinks in 'Additional courses in your local area' section

* Make content changes to hero banner

* Merge latest fac-beta 1 changes into release branch (v6) (#317)

* fixed clear filter bug (#306)




* Fixed pre-prod bugs facd-473 & 475

* Remove props file to ensure we use the intended dotnet core version

* Issue with Automapper in Azure app servie using lastest .NET runtime

* Revert "Issue with Automapper in Azure app servie using lastest .NET runtime"

This reverts commit d7748638782e05de8610a1efc3b8e07a55526d9c.

* Revert "Remove props file to ensure we use the intended dotnet core version"

This reverts commit 09ec622aaf711aa1b4dee1065755c668effc604d.

* Setting runtime to lastminor

* fixed read accessibility issue

* Added Additional courses for free course search

* fix trailing space in hyperlinks in 'Additional courses in your local area' section

* Make content changes to hero banner








* Change RollForward parameter to Minor in MSBuild props file

* Revert "Change RollForward parameter to Minor in MSBuild props file"

This reverts commit 3a8143e302a81c204adecc1803b2fbf66e104dbe.

* Change FAC headings to gov-heading-xl for consistency with other sections

* Merge latest fac-beta 1 changes into release branch (v7)  (#319)

* fixed clear filter bug (#306)




* Fixed pre-prod bugs facd-473 & 475

* Remove props file to ensure we use the intended dotnet core version

* Issue with Automapper in Azure app servie using lastest .NET runtime

* Revert "Issue with Automapper in Azure app servie using lastest .NET runtime"

This reverts commit d7748638782e05de8610a1efc3b8e07a55526d9c.

* Revert "Remove props file to ensure we use the intended dotnet core version"

This reverts commit 09ec622aaf711aa1b4dee1065755c668effc604d.

* Setting runtime to lastminor

* fixed read accessibility issue

* Added Additional courses for free course search

* fix trailing space in hyperlinks in 'Additional courses in your local area' section

* Make content changes to hero banner

* Cherry-pick FACD-488 into FAC Beta 1








* Create hyperlink in no results block back to FAC homepage

* Revert placement of apply filters and clear filters back to original position

* Remove whitespace between course attendance type and provider if course is online (#323)

* Added Rollforward env variables to stop it rolling forward runtimes

* Adding missing comma

* Revert "Create hyperlink in no results block back to FAC homepage"

This reverts commit 5633e14e27b13a7e6d72f444a7406e7145d6c74b.

* Amend wording on no results page according to BA spec

---------

[FT2-1319]: https://skillsfundingagency.atlassian.net/browse/FT2-1319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ